### PR TITLE
implement migrations sub-folder feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,18 @@ The first option to apply it to ```api``` group for example will be more comfort
     ];
 ```
 
-* Now you need to run the following ```command``` in order to migrate package tables and publish ```permissions.php``` config file to config directory
+* Now you need to run the following ```command``` in order to publish package migrations and publish ```permissions.php``` config file to config directory
 
 ```bash
 php artisan permission:setup
 ```
+
+* Then you need to run the following ```command``` in order to migrate package tables
+
+```bash
+php artisan migrate
+```
+
 
 ## Configurations according to project needs
 

--- a/src/Console/Commands/PermissionSetupCommand.php
+++ b/src/Console/Commands/PermissionSetupCommand.php
@@ -55,9 +55,6 @@ class PermissionSetupCommand extends Command
         $this->info('Caching configs...');
         $this->call('config:cache');
 
-        $this->info('Running migrate command...');
-        $this->call('migrate');
-
         return Command::SUCCESS;
     }
 

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -93,10 +93,11 @@ class PermissionServiceProvider extends ServiceProvider
     protected function migrationFiles()
     {
         $migrationFiles = [];
+        $basePath = $this->migrationsPublishPath();
 
         foreach ($this->packageMigrations as $migrationName) {
             if (! $this->migrationExists($migrationName)) {
-                $migrationFiles[__DIR__ . "/database/migrations/{$migrationName}.php.stub"] = database_path('migrations/' . date('Y_m_d_His', time()) . "_{$migrationName}.php");
+                $migrationFiles[__DIR__ . "/database/migrations/{$migrationName}.php.stub"] = $basePath . date('Y_m_d_His', time()) . "_{$migrationName}.php";
             }
         }
         return $migrationFiles;
@@ -104,7 +105,7 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function migrationExists($migrationName)
     {
-        $path = database_path('migrations/');
+        $path = $this->migrationsPublishPath();
         $files = scandir($path);
         $pos = false;
         foreach ($files as &$value) {
@@ -112,5 +113,11 @@ class PermissionServiceProvider extends ServiceProvider
             if ($pos !== false) return true;
         }
         return false;
+    }
+
+    protected function migrationsPublishPath()
+    {
+        $migrationSubFolder = config('permissions.migration_sub_folder', '');
+        return database_path('migrations/' . $migrationSubFolder . '/');
     }
 }

--- a/src/config/permissions.php
+++ b/src/config/permissions.php
@@ -134,4 +134,19 @@ return [
     */
 
     'base_permission_group_id' => 1,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Package migrations sub-folder
+    |--------------------------------------------------------------------------
+    |
+    | This configuration key specifies the sub-folder within the database/migrations
+    | directory where the package's migration files will be published. If the key
+    | is left empty, the migration files will be published directly to the
+    | database/migrations directory. If a sub-folder is specified, the migration
+    | files will be published to that sub-folder.
+    |
+    */
+
+    'migration_sub_folder' => '',
 ];


### PR DESCRIPTION
- Remove migrate command from package setup command.
- Add 'migration_sub_folder' key to config file.
- Modify publishing process to publish migrations in the specified sub-folder if exists in config file.
- Modify readme to reflect the new modifications.