### PR TITLE
Console command execution config key

### DIFF
--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -47,31 +47,33 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->registerRoutes();
 
-        if (config('permissions.should_run_command_from_console') && $this->app->runningInConsole()) {
-            $this->commands([
-                PermissionSetupCommand::class,
-                PermissionSeedCommand::class,
-            ]);
-
-            /**
-             * Migrations
-             */
-            $migrationFiles = $this->migrationFiles();
-            if (\count($migrationFiles) > 0) {
-                $this->publishes($migrationFiles, 'permission_migrations');
-            }
-
-            /**
-             * Config and static translations
-             */
-            $this->publishes([
-                __DIR__ . '/config/permissions.php' => config_path('permissions.php'), // ? Config
-                __DIR__ . '/resources/lang' => App::langPath(), // ? Static translations
-            ]);
-
-            $this->app->make(Router::class)
-                ->aliasMiddleware('permission-officer', PermissionOfficerMiddleware::class);
+        if (!config('permissions.should_run_command_from_console') && $this->app->runningInConsole()) {
+            throw new \RuntimeException('Execution from the console is disabled.  You can enable it by setting SHOULD_RUN_COMMAND_FROM_CONSOLE to true in the .env file');
         }
+
+        $this->commands([
+            PermissionSetupCommand::class,
+            PermissionSeedCommand::class,
+        ]);
+
+        /**
+         * Migrations
+         */
+        $migrationFiles = $this->migrationFiles();
+        if (\count($migrationFiles) > 0) {
+            $this->publishes($migrationFiles, 'permission_migrations');
+        }
+
+        /**
+         * Config and static translations
+         */
+        $this->publishes([
+            __DIR__ . '/config/permissions.php' => config_path('permissions.php'), // ? Config
+            __DIR__ . '/resources/lang' => App::langPath(), // ? Static translations
+        ]);
+
+        $this->app->make(Router::class)
+            ->aliasMiddleware('permission-officer', PermissionOfficerMiddleware::class);
     }
 
     protected function registerRoutes()

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -47,8 +47,7 @@ class PermissionServiceProvider extends ServiceProvider
 
         $this->registerRoutes();
 
-        if ($this->app->runningInConsole()) {
-
+        if (config('permissions.should_run_command_from_console') && $this->app->runningInConsole()) {
             $this->commands([
                 PermissionSetupCommand::class,
                 PermissionSeedCommand::class,

--- a/src/config/permissions.php
+++ b/src/config/permissions.php
@@ -149,4 +149,18 @@ return [
     */
 
     'migration_sub_folder' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Should Run Command From Console
+    |--------------------------------------------------------------------------
+    |
+    | This configuration key determines whether the permission commands should
+    | be run from the console. By default, it is set to true, meaning the
+    | commands will run from the console. You can change this value by setting
+    | the PERMISSION_COMMAND_SHOULD_RUN_FROM_CONSOLE environment variable.
+    |
+    */
+
+    'should_run_command_from_console' => env('PERMISSION_COMMAND_SHOULD_RUN_FROM_CONSOLE', true),
 ];


### PR DESCRIPTION
- Added `should_run_command_from_console` configuration key to `permissions.php` to control if permission commands should be executed from the console.
- Updated `PermissionServiceProvider` to check the new configuration key before registering console commands.