### PR TITLE
add new key in the config run_seed_in_production

### DIFF
--- a/src/Console/Commands/PermissionSeedCommand.php
+++ b/src/Console/Commands/PermissionSeedCommand.php
@@ -4,7 +4,6 @@ namespace Mabrouk\Permission\Console\Commands;
 
 use Illuminate\Console\Command;
 use Database\Seeders\RoleableSeeder;
-use Illuminate\Support\Facades\File;
 
 class PermissionSeedCommand extends Command
 {
@@ -45,7 +44,13 @@ class PermissionSeedCommand extends Command
 
         config(['translatable.translation_models_path' => 'Mabrouk\Permission\Models']);
 
-        $this->call('db:seed', ['--class' => RoleableSeeder::class]);
+        $seedOptions = ['--class' => RoleableSeeder::class];
+
+        if (config('translatable.run_seed_in_production')) {
+            $seedOptions['--force'] = true;
+        }
+        
+        $this->call('db:seed', $seedOptions);
 
         config(['translatable.translation_models_path' => $currentTranslationNamespace]);
 

--- a/src/Console/Commands/PermissionSeedCommand.php
+++ b/src/Console/Commands/PermissionSeedCommand.php
@@ -46,7 +46,7 @@ class PermissionSeedCommand extends Command
 
         $seedOptions = ['--class' => RoleableSeeder::class];
 
-        if (config('translatable.run_seed_in_production')) {
+        if (config('permissions.force_seeding_without_questions')) {
             $seedOptions['--force'] = true;
         }
         

--- a/src/config/permissions.php
+++ b/src/config/permissions.php
@@ -152,12 +152,12 @@ return [
     
     /*
     |--------------------------------------------------------------------------
-    | Run seeder in production env
+    | Force run seeder without questions
     |--------------------------------------------------------------------------
     |
-    | if this true, the seed commands in PermissionSeedCommand can be run in the production env using the force option
+    | Force seeding package seeder without interruption by questions in terminal. The default value is true so, if you like to stop forcing the seeder to run just change the value to false
     |
     */
 
-    'run_seed_in_production' => false,
+    'force_seeding_without_questions' => true,
 ];

--- a/src/config/permissions.php
+++ b/src/config/permissions.php
@@ -134,4 +134,15 @@ return [
     */
 
     'base_permission_group_id' => 1,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Run seeder in production env
+    |--------------------------------------------------------------------------
+    |
+    | if this true, the seed commands in PermissionSeedCommand can be run in the production env using the force option
+    |
+    */
+
+    'run_seed_in_production' => false,    
 ];


### PR DESCRIPTION
- add new config key "run_seed_in_production"
- update PermissionSeedCommand to include the "--force" option if the run_seed_in_production is true, when running the seeder commands