### PR TITLE
Add command to publish routes

### DIFF
--- a/src/Console/Commands/PermissionPublishRoutesCommand.php
+++ b/src/Console/Commands/PermissionPublishRoutesCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Mabrouk\Permission\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+
+class PermissionPublishRoutesCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'permission:publish-routes';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publish the routes for the Permission package';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $routesPublishSubDirectory = config('permissions.routes_publish_subdirectory');
+
+        if (File::exists(base_path("routes/{$routesPublishSubDirectory}permission_routes.php"))) {
+            $this->info("Routes have already been published in routes/{$routesPublishSubDirectory} directory.");
+            return Command::SUCCESS;
+        }
+
+        File::copy(
+            __DIR__ . "/../../routes/permission_routes.php",
+            base_path("routes/{$routesPublishSubDirectory}permission_routes.php")
+        );
+
+        $this->publishConfiguration();
+
+        $this->info('Routes have been published successfully.');
+
+        return Command::SUCCESS;
+    }
+
+    private function publishConfiguration($forcePublish = false)
+    {
+        $params = [
+            '--provider' => 'Mabrouk\Permission\PermissionServiceProvider',
+        ];
+
+        if ($forcePublish === true) {
+            $params['--force'] = true;
+        }
+
+        $this->call('vendor:publish', $params, new \Symfony\Component\Console\Output\NullOutput());
+    }
+}

--- a/src/Console/Commands/PermissionPublishRoutesCommand.php
+++ b/src/Console/Commands/PermissionPublishRoutesCommand.php
@@ -59,6 +59,8 @@ class PermissionPublishRoutesCommand extends Command
             '--provider' => 'Mabrouk\Permission\PermissionServiceProvider',
         ]);
 
+        exec('composer dump-autoload');
+
         $this->info('Routes have been published successfully.');
 
         return Command::SUCCESS;

--- a/src/PermissionServiceProvider.php
+++ b/src/PermissionServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Mabrouk\Permission\Console\Commands\PermissionPublishRoutesCommand;
 use Mabrouk\Permission\Console\Commands\PermissionSeedCommand;
 use Mabrouk\Permission\Console\Commands\PermissionSetupCommand;
 use Mabrouk\Permission\Http\Middleware\PermissionOfficerMiddleware;
@@ -50,6 +51,7 @@ class PermissionServiceProvider extends ServiceProvider
         $this->commands([
             PermissionSetupCommand::class,
             PermissionSeedCommand::class,
+            PermissionPublishRoutesCommand::class,
         ]);
 
         /**
@@ -74,9 +76,11 @@ class PermissionServiceProvider extends ServiceProvider
 
     protected function registerRoutes()
     {
-        Route::group($this->routeConfiguration(), function () {
-            $this->loadRoutesFrom(__DIR__ . '/routes/permission_routes.php');
-        });
+        if (config('permissions.load_routes')) {
+            Route::group($this->routeConfiguration(), function () {
+                $this->loadRoutesFrom(__DIR__ . '/routes/permission_routes.php');
+            });
+        }
     }
 
     protected function routeConfiguration()

--- a/src/config/permissions.php
+++ b/src/config/permissions.php
@@ -160,4 +160,28 @@ return [
     */
 
     'force_seeding_without_questions' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Routes publish subdirectory
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify the subdirectory where the package routes should be
+    | published inside the project's routes folder. This allows you to customize the location of the published
+    | routes files.
+    |
+    */
+    # eg: 'routes_publish_subdirectory' => 'custom/',
+    'routes_publish_subdirectory' => '',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load Routes
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether the package routes should be loaded.
+    | Set this value to true to load the routes, or false to disable them.
+    |
+    */
+    'load_routes' => true,
 ];


### PR DESCRIPTION
- Changes

1. Add PermissionPublishRoutesCommand to publish routes.
2. Add 'routes_publish_subdirectory' to specify routes should be published inside the project's routes folder.
3. Add 'load_routes' to enable/disable route registering from service provider.