### PR TITLE
Modify Permission Groups Seeder to get seeding data from config file

### DIFF
--- a/src/config/permissions.php
+++ b/src/config/permissions.php
@@ -195,4 +195,38 @@ return [
     |
     */
     'middlewares' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Permission Group
+    |--------------------------------------------------------------------------
+    |
+    | This configuration key specifies the default permission group that will
+    | be used to add all auto-generated permissions as children. You can modify
+    | the value here to reflect changes if needed. This currently support en and ar languages.
+    |
+    */
+    'default_permission_group' => [
+        'en' => [
+            'Basic Permissions',
+        ],
+        'ar' => [
+            'الصلاحيات الأساسية',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Additional Permission Groups
+    |--------------------------------------------------------------------------
+    |
+    | This configuration key specifies additional permission groups that can be
+    | used in the project. You can add more permission groups here as needed
+    | This currently support en and ar languages.
+    |
+    */
+    'additional_permission_groups' => [
+        'en' => [],
+        'ar' => [],
+    ],
 ];

--- a/src/database/seeders/PermissionGroupsTableSeeder.php
+++ b/src/database/seeders/PermissionGroupsTableSeeder.php
@@ -15,28 +15,18 @@ class PermissionGroupsTableSeeder extends Seeder
      */
     public function run()
     {
-        $permissionGroups = [
-            [
-                'name' => 'Basic Permissions',
-                'ar_name' => 'الصلاحيات الأساسية',
-            ],
-            [
-                'name' => 'Other Permissions',
-                'ar_name' => 'صلاحيات أخرى',
-            ],
-        ];
+        $permissionGroups = array_merge_recursive(
+            config('permissions.default_permission_group'),
+            config('permissions.additional_permission_groups')
+        );
 
         $currentPermissionGroupsInTable = PermissionGroupTranslation::pluck('name')->flatten()->toArray();
 
-        for ($i = 0; $i < \count($permissionGroups); $i++) {
-            if (! \in_array($permissionGroups[$i]['name'], $currentPermissionGroupsInTable)) {
-                $permissionGroup = PermissionGroup::create([])->translate([
-                    'name' => $permissionGroups[$i]['name'],
-                ], 'en');
-                if (\array_key_exists('ar_name', $permissionGroups[$i])) {
-                    $permissionGroup->translate([
-                        'name' => $permissionGroups[$i]['ar_name'],
-                    ], 'ar');
+        foreach ($permissionGroups['en'] as $index => $name) {
+            if (!\in_array($name, $currentPermissionGroupsInTable)) {
+                $permissionGroup = PermissionGroup::create([])->translate(['name' => $name], 'en');
+                if (isset($permissionGroups['ar'][$index])) {
+                    $permissionGroup->translate(['name' => $permissionGroups['ar'][$index]], 'ar');
                 }
             }
         }


### PR DESCRIPTION
- Changes

1. Add 'default_permission_group' and 'additional_permission_groups' config keys to permissions.php
2. Modify permission groups table seeder to use the values of the added keys as the seeding data